### PR TITLE
修正LaravelDb多sql只记录一个sql的问题

### DIFF
--- a/src/config/plugin/webman/arms/app.php
+++ b/src/config/plugin/webman/arms/app.php
@@ -3,4 +3,5 @@ return [
     'enable' => true,
     'app_name' => '你的应用名称', // 应用名称
     'endpoint_url' => '接入点url', // 进入后台 https://tracing.console.aliyun.com/ 获取
+    'time_interval' => 30, //30秒上报一次，尽量将上报对业务的影响减少到最低
 ];


### PR DESCRIPTION
1、统一LaravelDb和ThinkDb的sql收集方式；

2、增加上报时间参数设置（开发调试时，可以调整得小点，便于实时查看结果）；